### PR TITLE
chore/rename to parla

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,72 +1,50 @@
 {
-  "projectName": "ki-anfragen-frontend",
-  "projectOwner": "technologiestiftung",
-  "repoType": "github",
-  "repoHost": "https://github.com",
-  "files": [
-    "README.md"
-  ],
-  "imageSize": 64,
-  "commit": true,
-  "commitConvention": "angular",
-  "contributors": [
-    {
-      "login": "ff6347",
-      "name": "Fabian Morón Zirfas",
-      "avatar_url": "https://avatars.githubusercontent.com/u/315106?v=4",
-      "profile": "https://fabianmoronzirfas.me",
-      "contributions": [
-        "code",
-        "infra",
-        "design"
-      ]
-    },
-    {
-      "login": "Esshahn",
-      "name": "Ingo Hinterding",
-      "avatar_url": "https://avatars.githubusercontent.com/u/434355?v=4",
-      "profile": "http://www.awsm.de",
-      "contributions": [
-        "review",
-        "content",
-        "ideas"
-      ]
-    },
-    {
-      "login": "raphael-arce",
-      "name": "Raphael.A",
-      "avatar_url": "https://avatars.githubusercontent.com/u/8709861?v=4",
-      "profile": "https://github.com/raphael-arce",
-      "contributions": [
-        "code",
-        "review",
-        "bug"
-      ]
-    },
-    {
-      "login": "vogelino",
-      "name": "Lucas Vogel",
-      "avatar_url": "https://avatars.githubusercontent.com/u/2759340?v=4",
-      "profile": "http://vogelino.com",
-      "contributions": [
-        "review",
-        "code",
-        "bug"
-      ]
-    },
-    {
-      "login": "Jaszkowic",
-      "name": "Jonas Jaszkowic",
-      "avatar_url": "https://avatars.githubusercontent.com/u/10830180?v=4",
-      "profile": "https://github.com/Jaszkowic",
-      "contributions": [
-        "code",
-        "bug",
-        "review"
-      ]
-    }
-  ],
-  "contributorsPerLine": 7,
-  "skipCi": true,
-  "commitType": "docs"
+	"projectName": "@technologiestiftung/parla-frontend",
+	"projectOwner": "technologiestiftung",
+	"repoType": "github",
+	"repoHost": "https://github.com",
+	"files": ["README.md"],
+	"imageSize": 64,
+	"commit": true,
+	"commitConvention": "angular",
+	"contributors": [
+		{
+			"login": "ff6347",
+			"name": "Fabian Morón Zirfas",
+			"avatar_url": "https://avatars.githubusercontent.com/u/315106?v=4",
+			"profile": "https://fabianmoronzirfas.me",
+			"contributions": ["code", "infra", "design"]
+		},
+		{
+			"login": "Esshahn",
+			"name": "Ingo Hinterding",
+			"avatar_url": "https://avatars.githubusercontent.com/u/434355?v=4",
+			"profile": "http://www.awsm.de",
+			"contributions": ["review", "content", "ideas"]
+		},
+		{
+			"login": "raphael-arce",
+			"name": "Raphael.A",
+			"avatar_url": "https://avatars.githubusercontent.com/u/8709861?v=4",
+			"profile": "https://github.com/raphael-arce",
+			"contributions": ["code", "review", "bug"]
+		},
+		{
+			"login": "vogelino",
+			"name": "Lucas Vogel",
+			"avatar_url": "https://avatars.githubusercontent.com/u/2759340?v=4",
+			"profile": "http://vogelino.com",
+			"contributions": ["review", "code", "bug"]
+		},
+		{
+			"login": "Jaszkowic",
+			"name": "Jonas Jaszkowic",
+			"avatar_url": "https://avatars.githubusercontent.com/u/10830180?v=4",
+			"profile": "https://github.com/Jaszkowic",
+			"contributions": ["code", "bug", "review"]
+		}
+	],
+	"contributorsPerLine": 7,
+	"skipCi": true,
+	"commitType": "docs"
 }

--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_KI_ANFRAGEN_API_URL=http://localhost:8080
+NEXT_PUBLIC_KI_PARLA_API_URL=http://localhost:8080

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,211 +1,211 @@
-# [1.17.0](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.16.0...v1.17.0) (2023-11-30)
+# [1.17.0](https://github.com/technologiestiftung/parla-frontend/compare/v1.16.0...v1.17.0) (2023-11-30)
 
 
 ### Features
 
-* **Answer:** Add disclaimer after answer ([382e8e2](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/382e8e2d40a6cc9c0876a18d91db1b01b5aaf259))
+* **Answer:** Add disclaimer after answer ([382e8e2](https://github.com/technologiestiftung/parla-frontend/commit/382e8e2d40a6cc9c0876a18d91db1b01b5aaf259))
 
-# [1.16.0](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.15.0...v1.16.0) (2023-11-29)
+# [1.16.0](https://github.com/technologiestiftung/parla-frontend/compare/v1.15.0...v1.16.0) (2023-11-29)
 
 
 ### Features
 
-* add include_summary_in_response_generation flag ([#48](https://github.com/technologiestiftung/ki-anfragen-frontend/issues/48)) ([6de9ec1](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/6de9ec1ab3b73e80674bfbdb291ea2952af348a4))
+* add include_summary_in_response_generation flag ([#48](https://github.com/technologiestiftung/parla-frontend/issues/48)) ([6de9ec1](https://github.com/technologiestiftung/parla-frontend/commit/6de9ec1ab3b73e80674bfbdb291ea2952af348a4))
 
-# [1.15.0](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.14.0...v1.15.0) (2023-11-29)
+# [1.15.0](https://github.com/technologiestiftung/parla-frontend/compare/v1.14.0...v1.15.0) (2023-11-29)
 
 
 ### Bug Fixes
 
-* prevent example questions to change on rerender ([42ef465](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/42ef465a070e5e3d40b2f7a1bf5f09e2014d6373))
+* prevent example questions to change on rerender ([42ef465](https://github.com/technologiestiftung/parla-frontend/commit/42ef465a070e5e3d40b2f7a1bf5f09e2014d6373))
 
 
 ### Features
 
-* **faq:** Add FAQ page ([090176c](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/090176c700c6511706322e92466b288f06913261))
-* **ResultHistory:** Add functionality to clear history and remove entries ([a95354e](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/a95354e41bf4977862d38d6264853b623a2de717))
-* **SearchResultSection:** Show similarity as text ([6bd9963](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/6bd996342b1ed5d0e0cb047847a10cbee5b29b32))
+* **faq:** Add FAQ page ([090176c](https://github.com/technologiestiftung/parla-frontend/commit/090176c700c6511706322e92466b288f06913261))
+* **ResultHistory:** Add functionality to clear history and remove entries ([a95354e](https://github.com/technologiestiftung/parla-frontend/commit/a95354e41bf4977862d38d6264853b623a2de717))
+* **SearchResultSection:** Show similarity as text ([6bd9963](https://github.com/technologiestiftung/parla-frontend/commit/6bd996342b1ed5d0e0cb047847a10cbee5b29b32))
 
-# [1.14.0](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.13.0...v1.14.0) (2023-11-28)
+# [1.14.0](https://github.com/technologiestiftung/parla-frontend/compare/v1.13.0...v1.14.0) (2023-11-28)
 
 
 ### Features
 
-* randomly select 3 questions as example questions ([0f4236f](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/0f4236fd2bc783339b2f824f8636eafb6fbd4776))
+* randomly select 3 questions as example questions ([0f4236f](https://github.com/technologiestiftung/parla-frontend/commit/0f4236fd2bc783339b2f824f8636eafb6fbd4776))
 
-# [1.13.0](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.12.0...v1.13.0) (2023-11-27)
+# [1.13.0](https://github.com/technologiestiftung/parla-frontend/compare/v1.12.0...v1.13.0) (2023-11-27)
 
 
 ### Bug Fixes
 
-* **answer:** In case of NaN ignore count ([2926168](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/29261686bccfc667575b5af90a2bc970e38087fd))
+* **answer:** In case of NaN ignore count ([2926168](https://github.com/technologiestiftung/parla-frontend/commit/29261686bccfc667575b5af90a2bc970e38087fd))
 
 
 ### Features
 
-* **Answer:** Reintroduce summaries ([71e45dd](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/71e45dd9befd72885ab8da806ecefa851b8bb9b0))
-* **DocumentLoadingSkeleton:** Add new skeletons for documents ([10bc23e](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/10bc23ec14688626cd54446c55f7f534156cc230))
-* **page:** Load search and answer separately ([9fe2361](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/9fe23614f8b44a0d7a12c02ee06ea88491ed9e42))
-* **PromptForm:** Add submit on enter ([6c26387](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/6c263872a693a6a53024ad4a63cae9983e93cff3))
+* **Answer:** Reintroduce summaries ([71e45dd](https://github.com/technologiestiftung/parla-frontend/commit/71e45dd9befd72885ab8da806ecefa851b8bb9b0))
+* **DocumentLoadingSkeleton:** Add new skeletons for documents ([10bc23e](https://github.com/technologiestiftung/parla-frontend/commit/10bc23ec14688626cd54446c55f7f534156cc230))
+* **page:** Load search and answer separately ([9fe2361](https://github.com/technologiestiftung/parla-frontend/commit/9fe23614f8b44a0d7a12c02ee06ea88491ed9e42))
+* **PromptForm:** Add submit on enter ([6c26387](https://github.com/technologiestiftung/parla-frontend/commit/6c263872a693a6a53024ad4a63cae9983e93cff3))
 
-# [1.12.0](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.11.0...v1.12.0) (2023-11-27)
-
-
-### Features
-
-* added hook to show the splash screen only once, reworked info button ([32003e5](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/32003e5268dd5c546f6e9d2b6df5c6488e86710e))
-* adjusted info icon design, added hover on ki.anfrage anchor ([5c8dbdb](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/5c8dbdbcc8d2f3dde7ae75ee52188f7452581ccb))
-
-# [1.11.0](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.10.0...v1.11.0) (2023-11-27)
+# [1.12.0](https://github.com/technologiestiftung/parla-frontend/compare/v1.11.0...v1.12.0) (2023-11-27)
 
 
 ### Features
 
-* **Markdown:** Adds ReactMarkdown component ([0bce033](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/0bce0330f4b5d2d50f2e01c8d4e151e3916e65f7))
+* added hook to show the splash screen only once, reworked info button ([32003e5](https://github.com/technologiestiftung/parla-frontend/commit/32003e5268dd5c546f6e9d2b6df5c6488e86710e))
+* adjusted info icon design, added hover on ki.anfrage anchor ([5c8dbdb](https://github.com/technologiestiftung/parla-frontend/commit/5c8dbdbcc8d2f3dde7ae75ee52188f7452581ccb))
 
-# [1.10.0](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.9.1...v1.10.0) (2023-11-23)
+# [1.11.0](https://github.com/technologiestiftung/parla-frontend/compare/v1.10.0...v1.11.0) (2023-11-27)
+
+
+### Features
+
+* **Markdown:** Adds ReactMarkdown component ([0bce033](https://github.com/technologiestiftung/parla-frontend/commit/0bce0330f4b5d2d50f2e01c8d4e151e3916e65f7))
+
+# [1.10.0](https://github.com/technologiestiftung/parla-frontend/compare/v1.9.1...v1.10.0) (2023-11-23)
 
 
 ### Bug Fixes
 
-* **examplePrompts:** Auto submit example prompts on click ([7448c46](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/7448c4627563ba000e5e0d3553048d4d0d05d2ab))
-* **Sidebar:** Reintroduce history in sidebar ([62eec6c](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/62eec6cfafd60667616d37a94eb4fa825aa1266c))
+* **examplePrompts:** Auto submit example prompts on click ([7448c46](https://github.com/technologiestiftung/parla-frontend/commit/7448c4627563ba000e5e0d3553048d4d0d05d2ab))
+* **Sidebar:** Reintroduce history in sidebar ([62eec6c](https://github.com/technologiestiftung/parla-frontend/commit/62eec6cfafd60667616d37a94eb4fa825aa1266c))
 
 
 ### Features
 
-* **SearchResultSection:** reintroduce tags ([1ff5bbd](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/1ff5bbda1ad260eac76f0764250dd2d685a1e6e9))
+* **SearchResultSection:** reintroduce tags ([1ff5bbd](https://github.com/technologiestiftung/parla-frontend/commit/1ff5bbda1ad260eac76f0764250dd2d685a1e6e9))
 
-## [1.9.1](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.9.0...v1.9.1) (2023-11-23)
+## [1.9.1](https://github.com/technologiestiftung/parla-frontend/compare/v1.9.0...v1.9.1) (2023-11-23)
 
 
 ### Bug Fixes
 
-* **AcrobatIcon:** Fix attribute format in SVG ([eab8d08](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/eab8d08af0b9fbe664b386c6e6f3f096ac2af418))
-* Multiple fixes based on [@esshahn](https://github.com/esshahn) comments (see commit description) ([e8f88b0](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/e8f88b0e97138bd0c80bd311a4b0f9de5537be3f))
-* **splash-screen:** Click doesnt close modal ([59304e3](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/59304e39d87e6660741f4263e9866bdbce58a20a))
+* **AcrobatIcon:** Fix attribute format in SVG ([eab8d08](https://github.com/technologiestiftung/parla-frontend/commit/eab8d08af0b9fbe664b386c6e6f3f096ac2af418))
+* Multiple fixes based on [@esshahn](https://github.com/esshahn) comments (see commit description) ([e8f88b0](https://github.com/technologiestiftung/parla-frontend/commit/e8f88b0e97138bd0c80bd311a4b0f9de5537be3f))
+* **splash-screen:** Click doesnt close modal ([59304e3](https://github.com/technologiestiftung/parla-frontend/commit/59304e39d87e6660741f4263e9866bdbce58a20a))
 
-# [1.9.0](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.8.0...v1.9.0) (2023-11-20)
+# [1.9.0](https://github.com/technologiestiftung/parla-frontend/compare/v1.8.0...v1.9.0) (2023-11-20)
 
 
 ### Features
 
-* toggle algorithms ([#31](https://github.com/technologiestiftung/ki-anfragen-frontend/issues/31)) ([50b0934](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/50b09349d8ff8e3d3c4b22b227f5a8deae0a65b9))
+* toggle algorithms ([#31](https://github.com/technologiestiftung/parla-frontend/issues/31)) ([50b0934](https://github.com/technologiestiftung/parla-frontend/commit/50b09349d8ff8e3d3c4b22b227f5a8deae0a65b9))
 
-# [1.8.0](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.7.0...v1.8.0) (2023-11-14)
+# [1.8.0](https://github.com/technologiestiftung/parla-frontend/compare/v1.7.0...v1.8.0) (2023-11-14)
 
 
 ### Bug Fixes
 
-* build error ([bdf553f](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/bdf553fbdd65ebfdd6b771ba1080c091f763a6a1))
+* build error ([bdf553f](https://github.com/technologiestiftung/parla-frontend/commit/bdf553fbdd65ebfdd6b771ba1080c091f763a6a1))
 
 
 ### Features
 
-* adapt to new response schema ([939fee9](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/939fee93f3f85592e975c7ba0935083ac40d6cf1))
-* **SearchResultSection:** Add tags to the mix ([393cb65](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/393cb65b4327876c396c4a8c9b71f082618acdf6))
+* adapt to new response schema ([939fee9](https://github.com/technologiestiftung/parla-frontend/commit/939fee93f3f85592e975c7ba0935083ac40d6cf1))
+* **SearchResultSection:** Add tags to the mix ([393cb65](https://github.com/technologiestiftung/parla-frontend/commit/393cb65b4327876c396c4a8c9b71f082618acdf6))
 
-# [1.7.0](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.6.2...v1.7.0) (2023-11-14)
+# [1.7.0](https://github.com/technologiestiftung/parla-frontend/compare/v1.6.2...v1.7.0) (2023-11-14)
 
 
 ### Features
 
-* adapt to new API response ([#30](https://github.com/technologiestiftung/ki-anfragen-frontend/issues/30)) ([381dae6](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/381dae6f5636b0b746a79ccfd82a452aadd64224))
+* adapt to new API response ([#30](https://github.com/technologiestiftung/parla-frontend/issues/30)) ([381dae6](https://github.com/technologiestiftung/parla-frontend/commit/381dae6f5636b0b746a79ccfd82a452aadd64224))
 
-## [1.6.2](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.6.1...v1.6.2) (2023-11-06)
+## [1.6.2](https://github.com/technologiestiftung/parla-frontend/compare/v1.6.1...v1.6.2) (2023-11-06)
 
 
 ### Bug Fixes
 
-* add mobile sidebar ([2faa31d](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/2faa31d031bdd0b4616f98c82b9d0f3670df2366))
-* add padding to main ([26d7163](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/26d7163e452f6dfd813299f7503f066d87f5ff33))
+* add mobile sidebar ([2faa31d](https://github.com/technologiestiftung/parla-frontend/commit/2faa31d031bdd0b4616f98c82b9d0f3670df2366))
+* add padding to main ([26d7163](https://github.com/technologiestiftung/parla-frontend/commit/26d7163e452f6dfd813299f7503f066d87f5ff33))
 
-## [1.6.1](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.6.0...v1.6.1) (2023-11-02)
-
-
-### Bug Fixes
-
-* build errors ([248aa80](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/248aa800e9cb35a9dbe4f5a2da03d968da2eb2e6))
-
-# [1.6.0](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.5.0...v1.6.0) (2023-11-02)
-
-
-### Features
-
-* UI revamp + results from different doc sources ([#17](https://github.com/technologiestiftung/ki-anfragen-frontend/issues/17)) ([ac24aaf](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/ac24aafa347a84e944e00d28bb6f061c00ce3552))
-
-# [1.5.0](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.4.0...v1.5.0) (2023-09-01)
+## [1.6.1](https://github.com/technologiestiftung/parla-frontend/compare/v1.6.0...v1.6.1) (2023-11-02)
 
 
 ### Bug Fixes
 
-* **icon:** Remove flashing by including fa css ([67c4c9f](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/67c4c9f38b4c28c3bb9a29a57125c2c116a66831))
-* **iconsa:** remve icon flash ([218fd67](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/218fd672ca39727c942e6728b2689ee5ae754c1d))
+* build errors ([248aa80](https://github.com/technologiestiftung/parla-frontend/commit/248aa800e9cb35a9dbe4f5a2da03d968da2eb2e6))
+
+# [1.6.0](https://github.com/technologiestiftung/parla-frontend/compare/v1.5.0...v1.6.0) (2023-11-02)
 
 
 ### Features
 
-* **layout:** Make layout more condensed ([179081b](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/179081b7faf0a492ab14747a776fa5162615089d))
-* **search:** WIP Make ui more condensed ([06456b9](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/06456b9abb953addcb6a9882333b6dd7e2762f27))
+* UI revamp + results from different doc sources ([#17](https://github.com/technologiestiftung/parla-frontend/issues/17)) ([ac24aaf](https://github.com/technologiestiftung/parla-frontend/commit/ac24aafa347a84e944e00d28bb6f061c00ce3552))
 
-# [1.4.0](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.3.2...v1.4.0) (2023-08-31)
-
-
-### Features
-
-* 5 rows in textarea ([80986ab](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/80986ab85ad6960905970a6b6b344afc9288288e))
-
-## [1.3.2](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.3.1...v1.3.2) (2023-08-31)
+# [1.5.0](https://github.com/technologiestiftung/parla-frontend/compare/v1.4.0...v1.5.0) (2023-09-01)
 
 
 ### Bug Fixes
 
-* typos ([3c8cea0](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/3c8cea0a6d197ced133197a5a588112011f2a05f))
+* **icon:** Remove flashing by including fa css ([67c4c9f](https://github.com/technologiestiftung/parla-frontend/commit/67c4c9f38b4c28c3bb9a29a57125c2c116a66831))
+* **iconsa:** remve icon flash ([218fd67](https://github.com/technologiestiftung/parla-frontend/commit/218fd672ca39727c942e6728b2689ee5ae754c1d))
 
-## [1.3.1](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.3.0...v1.3.1) (2023-08-30)
+
+### Features
+
+* **layout:** Make layout more condensed ([179081b](https://github.com/technologiestiftung/parla-frontend/commit/179081b7faf0a492ab14747a776fa5162615089d))
+* **search:** WIP Make ui more condensed ([06456b9](https://github.com/technologiestiftung/parla-frontend/commit/06456b9abb953addcb6a9882333b6dd7e2762f27))
+
+# [1.4.0](https://github.com/technologiestiftung/parla-frontend/compare/v1.3.2...v1.4.0) (2023-08-31)
+
+
+### Features
+
+* 5 rows in textarea ([80986ab](https://github.com/technologiestiftung/parla-frontend/commit/80986ab85ad6960905970a6b6b344afc9288288e))
+
+## [1.3.2](https://github.com/technologiestiftung/parla-frontend/compare/v1.3.1...v1.3.2) (2023-08-31)
+
 
 ### Bug Fixes
 
-- **types:** type was not renamed in Label ([377b782](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/377b782f271280d95c978124d049d62429d687c7))
+* typos ([3c8cea0](https://github.com/technologiestiftung/parla-frontend/commit/3c8cea0a6d197ced133197a5a588112011f2a05f))
 
-# [1.3.0](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.2.0...v1.3.0) (2023-08-29)
-
-### Features
-
-- Icons with tooltips ([43b470b](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/43b470b58bf16ea3279990fc41a601bccefae636))
-- **search paramters:** Add opts to tweak request ([e315722](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/e3157220ab684924d9b7dc31937e222a6bdc74b3))
-
-# [1.2.0](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.1.0...v1.2.0) (2023-08-25)
-
-### Features
-
-- **SearchResult:** Sorted by similarity ([bf702d6](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/bf702d662b75deed29c5ab6e13c4a88b8be77fc4))
-
-# [1.1.0](https://github.com/technologiestiftung/ki-anfragen-frontend/compare/v1.0.0...v1.1.0) (2023-08-25)
+## [1.3.1](https://github.com/technologiestiftung/parla-frontend/compare/v1.3.0...v1.3.1) (2023-08-30)
 
 ### Bug Fixes
 
-- Missing type ([0c919f5](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/0c919f501244e6d7e1ba3884fb75e499966ef8e6))
-- Width on small screens ([ab3a31c](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/ab3a31cd308135678bdb9dc5235386444f3c0d15))
+- **types:** type was not renamed in Label ([377b782](https://github.com/technologiestiftung/parla-frontend/commit/377b782f271280d95c978124d049d62429d687c7))
+
+# [1.3.0](https://github.com/technologiestiftung/parla-frontend/compare/v1.2.0...v1.3.0) (2023-08-29)
 
 ### Features
 
-- Duplicate call to api with larger text chunks ([168e963](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/168e9631f3fbfa90b9c05d1da9bbe41687234727))
-- **explorer:** adds reponse data as table ([3ccacc2](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/3ccacc29312296a084f13775c7720883e111bcf8))
-- Favicon ([a89e3cd](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/a89e3cd2b576d51826f1968d86aa9617fa1d4517))
-- Markdown rendering ([f74adbc](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/f74adbccc12ada86e32178c4959327630bbc62d2))
-- Max tokens based on model ([c200a2c](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/c200a2ce67a92fe156adc3d2beaa1b5cddb02824))
-- Prompt creation in own function ([36a618d](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/36a618d32256fcabd21082751d52c03fadfb047a))
-- Refine prompt ([9bd9d36](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/9bd9d3684f66335c881380c4e0a54cc9abdb7208))
-- Results as component for double tests ([1f1ea6a](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/1f1ea6a5f215fe9ec2fc5e0552101c45eb54f1f3))
+- Icons with tooltips ([43b470b](https://github.com/technologiestiftung/parla-frontend/commit/43b470b58bf16ea3279990fc41a601bccefae636))
+- **search paramters:** Add opts to tweak request ([e315722](https://github.com/technologiestiftung/parla-frontend/commit/e3157220ab684924d9b7dc31937e222a6bdc74b3))
+
+# [1.2.0](https://github.com/technologiestiftung/parla-frontend/compare/v1.1.0...v1.2.0) (2023-08-25)
+
+### Features
+
+- **SearchResult:** Sorted by similarity ([bf702d6](https://github.com/technologiestiftung/parla-frontend/commit/bf702d662b75deed29c5ab6e13c4a88b8be77fc4))
+
+# [1.1.0](https://github.com/technologiestiftung/parla-frontend/compare/v1.0.0...v1.1.0) (2023-08-25)
+
+### Bug Fixes
+
+- Missing type ([0c919f5](https://github.com/technologiestiftung/parla-frontend/commit/0c919f501244e6d7e1ba3884fb75e499966ef8e6))
+- Width on small screens ([ab3a31c](https://github.com/technologiestiftung/parla-frontend/commit/ab3a31cd308135678bdb9dc5235386444f3c0d15))
+
+### Features
+
+- Duplicate call to api with larger text chunks ([168e963](https://github.com/technologiestiftung/parla-frontend/commit/168e9631f3fbfa90b9c05d1da9bbe41687234727))
+- **explorer:** adds reponse data as table ([3ccacc2](https://github.com/technologiestiftung/parla-frontend/commit/3ccacc29312296a084f13775c7720883e111bcf8))
+- Favicon ([a89e3cd](https://github.com/technologiestiftung/parla-frontend/commit/a89e3cd2b576d51826f1968d86aa9617fa1d4517))
+- Markdown rendering ([f74adbc](https://github.com/technologiestiftung/parla-frontend/commit/f74adbccc12ada86e32178c4959327630bbc62d2))
+- Max tokens based on model ([c200a2c](https://github.com/technologiestiftung/parla-frontend/commit/c200a2ce67a92fe156adc3d2beaa1b5cddb02824))
+- Prompt creation in own function ([36a618d](https://github.com/technologiestiftung/parla-frontend/commit/36a618d32256fcabd21082751d52c03fadfb047a))
+- Refine prompt ([9bd9d36](https://github.com/technologiestiftung/parla-frontend/commit/9bd9d3684f66335c881380c4e0a54cc9abdb7208))
+- Results as component for double tests ([1f1ea6a](https://github.com/technologiestiftung/parla-frontend/commit/1f1ea6a5f215fe9ec2fc5e0552101c45eb54f1f3))
 
 # 1.0.0 (2023-08-18)
 
 ### Bug Fixes
 
-- **empty query:** Check if query is empty ([6bb8bf8](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/6bb8bf84a4b3eac2c0b2868e8ddbc7c898dc19ec))
-- **runtime:** Change runtime export ([1e4b968](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/1e4b9686a777cdccc56e2ec0b8e809722dbfb4b3))
+- **empty query:** Check if query is empty ([6bb8bf8](https://github.com/technologiestiftung/parla-frontend/commit/6bb8bf84a4b3eac2c0b2868e8ddbc7c898dc19ec))
+- **runtime:** Change runtime export ([1e4b968](https://github.com/technologiestiftung/parla-frontend/commit/1e4b9686a777cdccc56e2ec0b8e809722dbfb4b3))
 
 ### Features
 
-- Types and better prompt ([041ac0a](https://github.com/technologiestiftung/ki-anfragen-frontend/commit/041ac0adeffd9d1fccba8601ff773bcf07dff107))
+- Types and better prompt ([041ac0a](https://github.com/technologiestiftung/parla-frontend/commit/041ac0adeffd9d1fccba8601ff773bcf07dff107))

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ sequenceDiagram
 
 - vercel.com account
 - supabase.com account
-- running instance of the related API and database https://github.com/technologiestiftung/ki-anfragen-api
-- Populated database. Using these tools https://github.com/technologiestiftung/ki-anfragen-document-processor
+- running instance of the related API and database https://github.com/technologiestiftung/parla-api
+- Populated database. Using these tools https://github.com/technologiestiftung/parla-document-processor
 
 ## Needed Environment Variables
 
 ```plain
-NEXT_PUBLIC_KI_ANFRAGEN_API_URL=https://domain-of-your-api-server.dev
+NEXT_PUBLIC_PARLA_API_URL=https://domain-of-your-api-server.dev
 ```
 
 ## Installation
@@ -62,7 +62,7 @@ Assuming you have a vercel.com account and you are logged in.
 # does the first deployment and project creation
 npx vercel
 # add your env variables (interactive)
-npx vercel env add NEXT_PUBLIC_KI_ANFRAGEN_API_URL
+npx vercel env add NEXT_PUBLIC_PARLA_API_URL
 # deploy again for production
 npx vercel --prod
 ```
@@ -99,11 +99,11 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <table>
   <tbody>
     <tr>
-      <td align="center" valign="top" width="14.28%"><a href="https://fabianmoronzirfas.me"><img src="https://avatars.githubusercontent.com/u/315106?v=4?s=64" width="64px;" alt="Fabian Morón Zirfas"/><br /><sub><b>Fabian Morón Zirfas</b></sub></a><br /><a href="https://github.com/technologiestiftung/ki-anfragen-frontend/commits?author=ff6347" title="Code">💻</a> <a href="#infra-ff6347" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#design-ff6347" title="Design">🎨</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="http://www.awsm.de"><img src="https://avatars.githubusercontent.com/u/434355?v=4?s=64" width="64px;" alt="Ingo Hinterding"/><br /><sub><b>Ingo Hinterding</b></sub></a><br /><a href="https://github.com/technologiestiftung/ki-anfragen-frontend/pulls?q=is%3Apr+reviewed-by%3AEsshahn" title="Reviewed Pull Requests">👀</a> <a href="#content-Esshahn" title="Content">🖋</a> <a href="#ideas-Esshahn" title="Ideas, Planning, & Feedback">🤔</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/raphael-arce"><img src="https://avatars.githubusercontent.com/u/8709861?v=4?s=64" width="64px;" alt="Raphael.A"/><br /><sub><b>Raphael.A</b></sub></a><br /><a href="https://github.com/technologiestiftung/ki-anfragen-frontend/commits?author=raphael-arce" title="Code">💻</a> <a href="https://github.com/technologiestiftung/ki-anfragen-frontend/pulls?q=is%3Apr+reviewed-by%3Araphael-arce" title="Reviewed Pull Requests">👀</a> <a href="https://github.com/technologiestiftung/ki-anfragen-frontend/issues?q=author%3Araphael-arce" title="Bug reports">🐛</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="http://vogelino.com"><img src="https://avatars.githubusercontent.com/u/2759340?v=4?s=64" width="64px;" alt="Lucas Vogel"/><br /><sub><b>Lucas Vogel</b></sub></a><br /><a href="https://github.com/technologiestiftung/ki-anfragen-frontend/pulls?q=is%3Apr+reviewed-by%3Avogelino" title="Reviewed Pull Requests">👀</a> <a href="https://github.com/technologiestiftung/ki-anfragen-frontend/commits?author=vogelino" title="Code">💻</a> <a href="https://github.com/technologiestiftung/ki-anfragen-frontend/issues?q=author%3Avogelino" title="Bug reports">🐛</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Jaszkowic"><img src="https://avatars.githubusercontent.com/u/10830180?v=4?s=64" width="64px;" alt="Jonas Jaszkowic"/><br /><sub><b>Jonas Jaszkowic</b></sub></a><br /><a href="https://github.com/technologiestiftung/ki-anfragen-frontend/commits?author=Jaszkowic" title="Code">💻</a> <a href="https://github.com/technologiestiftung/ki-anfragen-frontend/issues?q=author%3AJaszkowic" title="Bug reports">🐛</a> <a href="https://github.com/technologiestiftung/ki-anfragen-frontend/pulls?q=is%3Apr+reviewed-by%3AJaszkowic" title="Reviewed Pull Requests">👀</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://fabianmoronzirfas.me"><img src="https://avatars.githubusercontent.com/u/315106?v=4?s=64" width="64px;" alt="Fabian Morón Zirfas"/><br /><sub><b>Fabian Morón Zirfas</b></sub></a><br /><a href="https://github.com/technologiestiftung/parla-frontend/commits?author=ff6347" title="Code">💻</a> <a href="#infra-ff6347" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#design-ff6347" title="Design">🎨</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="http://www.awsm.de"><img src="https://avatars.githubusercontent.com/u/434355?v=4?s=64" width="64px;" alt="Ingo Hinterding"/><br /><sub><b>Ingo Hinterding</b></sub></a><br /><a href="https://github.com/technologiestiftung/parla-frontend/pulls?q=is%3Apr+reviewed-by%3AEsshahn" title="Reviewed Pull Requests">👀</a> <a href="#content-Esshahn" title="Content">🖋</a> <a href="#ideas-Esshahn" title="Ideas, Planning, & Feedback">🤔</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/raphael-arce"><img src="https://avatars.githubusercontent.com/u/8709861?v=4?s=64" width="64px;" alt="Raphael.A"/><br /><sub><b>Raphael.A</b></sub></a><br /><a href="https://github.com/technologiestiftung/parla-frontend/commits?author=raphael-arce" title="Code">💻</a> <a href="https://github.com/technologiestiftung/parla-frontend/pulls?q=is%3Apr+reviewed-by%3Araphael-arce" title="Reviewed Pull Requests">👀</a> <a href="https://github.com/technologiestiftung/parla-frontend/issues?q=author%3Araphael-arce" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="http://vogelino.com"><img src="https://avatars.githubusercontent.com/u/2759340?v=4?s=64" width="64px;" alt="Lucas Vogel"/><br /><sub><b>Lucas Vogel</b></sub></a><br /><a href="https://github.com/technologiestiftung/parla-frontend/pulls?q=is%3Apr+reviewed-by%3Avogelino" title="Reviewed Pull Requests">👀</a> <a href="https://github.com/technologiestiftung/parla-frontend/commits?author=vogelino" title="Code">💻</a> <a href="https://github.com/technologiestiftung/parla-frontend/issues?q=author%3Avogelino" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Jaszkowic"><img src="https://avatars.githubusercontent.com/u/10830180?v=4?s=64" width="64px;" alt="Jonas Jaszkowic"/><br /><sub><b>Jonas Jaszkowic</b></sub></a><br /><a href="https://github.com/technologiestiftung/parla-frontend/commits?author=Jaszkowic" title="Code">💻</a> <a href="https://github.com/technologiestiftung/parla-frontend/issues?q=author%3AJaszkowic" title="Bug reports">🐛</a> <a href="https://github.com/technologiestiftung/parla-frontend/pulls?q=is%3Apr+reviewed-by%3AJaszkowic" title="Reviewed Pull Requests">👀</a></td>
     </tr>
   </tbody>
 </table>
@@ -145,9 +145,9 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 
 ## Related Projects
 
-- https://github.com/technologiestiftung/ki-anfragen-api
-- https://github.com/technologiestiftung/ki-anfragen-data-extractor
-- https://github.com/technologiestiftung/ki-anfragen-supabase
+- https://github.com/technologiestiftung/parla-api
+- https://github.com/technologiestiftung/parla-data-extractor
+- https://github.com/technologiestiftung/parla-supabase
 - https://github.com/technologiestiftung/oeffentliches-gestalten-gpt-search
 - https://github.com/supabase-community/nextjs-openai-doc-search
 <!-- touch again -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "ki-anfragen-frontend",
+	"name": "@technologiestiftung/parla-frontend",
 	"version": "1.17.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "ki-anfragen-frontend",
+			"name": "@technologiestiftung/parla-frontend",
 			"version": "1.17.0",
 			"dependencies": {
 				"@headlessui/react": "1.7.17",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,7 +43,7 @@ export default function Home() {
 	const [_errors, setErrors] = useState<Record<string, any> | null>(null);
 	const [sidebarIsOpen, setSidebarIsOpen] = useState(false);
 	const [resultHistory, setResultHistory] = useLocalStorage<HistoryEntryType[]>(
-		"ki-anfragen-history",
+		"parla-history",
 		[],
 	);
 	const { showSplashScreenRef } = useShowSplashScreenFromLocalStorage();

--- a/src/components/splash-screen.tsx
+++ b/src/components/splash-screen.tsx
@@ -119,7 +119,7 @@ export function SplashScreen({
 					</Link>
 					<Link
 						className="text-sm"
-						href="https://github.com/technologiestiftung/ki-anfragen-frontend"
+						href="https://github.com/technologiestiftung/parla-frontend"
 					>
 						Quellcode
 					</Link>

--- a/src/lib/generate-answer.ts
+++ b/src/lib/generate-answer.ts
@@ -1,7 +1,7 @@
 import { GenerateAnswerResponse, GenerateAnswerBody } from "./common";
 
 const API_URL =
-	process.env.NEXT_PUBLIC_KI_ANFRAGEN_API_URL || "http://localhost:8080";
+	process.env.NEXT_PUBLIC_PARLA_API_URL || "http://localhost:8080";
 
 type InputType = GenerateAnswerBody & {
 	signal?: AbortSignal;

--- a/src/lib/get-documents-count.ts
+++ b/src/lib/get-documents-count.ts
@@ -1,5 +1,5 @@
 const API_URL =
-	process.env.NEXT_PUBLIC_KI_ANFRAGEN_API_URL || "http://localhost:8080";
+	process.env.NEXT_PUBLIC_PARLA_API_URL || "http://localhost:8080";
 
 export const getDocumentsCount = async (): Promise<number> => {
 	const response = await fetch(`${API_URL}/processed_documents/count`);

--- a/src/lib/vector-search.ts
+++ b/src/lib/vector-search.ts
@@ -1,7 +1,7 @@
 import { DocumentSearchResponse, DocumentSearchBody } from "./common";
 
 const API_URL =
-	process.env.NEXT_PUBLIC_KI_ANFRAGEN_API_URL || "http://localhost:8080";
+	process.env.NEXT_PUBLIC_PARLA_API_URL || "http://localhost:8080";
 
 type InputType = DocumentSearchBody & {
 	signal?: AbortSignal;


### PR DESCRIPTION
This PR should be merged after the API PR https://github.com/technologiestiftung/ki-anfragen-api/pull/48

What are the steps to take?:

- [x] Disconnect vercel project 
- [x] Rename repo
- [x] Reconnect vercel project to this repo or create new one if not possible
- [x] Adjust env variable `NEXT_PUBLIC_PARLA_API_URL` to point to new deploy of API
- [x] deploy with new ENV