### PR TITLE
chore: add nbsps to prevent line break

### DIFF
--- a/src/lib/texts.tsx
+++ b/src/lib/texts.tsx
@@ -12,7 +12,7 @@ export const texts = {
 	documentsTitle: "Beste Treffer in diesen Dokumenten:",
 	feedback: {
 		short: "Feedback",
-		long: "Beantworte&nsbp;uns&nsbp;gerne&nsbp;einige&nsbp;Fragen.",
+		long: "Beantworte&nbsp;uns&nbsp;gerne&nbsp;einige&nbsp;Fragen.",
 		question: "Wie gefällt Dir Parla? ",
 	},
 	about: {


### PR DESCRIPTION
I know it's not pretty. A better way might be to check for the breakpoint and add a line break if on mobile. 