### PR TITLE
feat: handle generate-answer error / restore from history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -299,3 +299,6 @@ next-env.d.ts
 .vscode/extensions.json
 .vscode/launch.json
 .vscode/settings.json
+
+# Jetbrains IDE
+.idea

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -87,7 +87,7 @@ function App() {
 		if (requestId) {
 			restoreResultHistoryItem(requestId);
 		}
-	}, [requestId, stateIsLoading]);
+	}, [requestId, stateIsLoading, answerIsLoading]);
 
 	async function onSubmit(query: string | null) {
 		setErrors(null);
@@ -197,8 +197,13 @@ function App() {
 		if (historyEntry) {
 			resetState();
 			setSearchResult(historyEntry.searchResponse);
-			setGeneratedAnswer(historyEntry.answerResponse);
+			if (!historyEntry.answerResponse) {
+				setErrors({ query: "historyEntry does not have an answer response" });
+			} else {
+				setGeneratedAnswer(historyEntry.answerResponse);
+			}
 			setTitle(historyEntry.query);
+			setFormData((s) => ({ ...s, query: historyEntry!.query }));
 			window.history.pushState({}, "", `/${historyEntry.id}`);
 		}
 	}

--- a/src/lib/generate-answer.ts
+++ b/src/lib/generate-answer.ts
@@ -30,7 +30,7 @@ export async function generateAnswer({
 		}),
 	});
 
-	if (!response.body) {
+	if (!response.ok || !response.body) {
 		throw new Error("Could not generate answer");
 	}
 

--- a/src/mock/fixtures.ts
+++ b/src/mock/fixtures.ts
@@ -244,4 +244,5 @@ export const vectorSearchResponse = {
 			similarity: 0.884143859148026,
 		},
 	],
+	userRequestId: "XYZ",
 };


### PR DESCRIPTION
this PR handles `generate-answer` API call errors and restoring according history entries.

~! Needs this PR to be merged beforehand: https://github.com/technologiestiftung/parla-api/pull/87 !~ edit: has been merged.