### PR TITLE
fix: only provide feedback to the currently selected request

### DIFF
--- a/src/components/ui/answer-feedback.tsx
+++ b/src/components/ui/answer-feedback.tsx
@@ -42,6 +42,9 @@ export function AnswerFeedback({
 	}, [resultHistory, requestId]);
 
 	useEffect(() => {
+		setIsThumbsUpClicked(false);
+		setIsThumbsDownClicked(false);
+
 		const loadData = async () => {
 			setAllFeedbacks(await getAllFeedbacks());
 		};
@@ -50,10 +53,12 @@ export function AnswerFeedback({
 		const userRequestHistory = resultHistory.find(
 			(entry) => entry.id === requestId,
 		);
+
 		const feedbacks = userRequestHistory?.feedbacks;
 		const feedbackFromSameSession = feedbacks?.find(
 			(feedback) => feedback.session_id === getSessionId(),
 		);
+
 		if (requestId) {
 			switch (feedbackFromSameSession?.feedback_id) {
 				case 1:
@@ -88,13 +93,16 @@ export function AnswerFeedback({
 		});
 		setResultHistory(
 			resultHistory.map((userRequest) => {
+				if (userRequest.id !== requestId) {
+					return { ...userRequest };
+				}
+
 				let feedbackIndex = userRequest.feedbacks.findIndex(
 					(feedback) => feedback.session_id === getSessionId(),
 				);
 
 				if (feedbackIndex === -1) {
 					userRequest.feedbacks.push({
-						request_id: Number(requestId),
 						feedback_id: feedbackId,
 						session_id: getSessionId(),
 					});

--- a/src/components/ui/answer-feedback.tsx
+++ b/src/components/ui/answer-feedback.tsx
@@ -81,6 +81,13 @@ export function AnswerFeedback({
 		}
 	}, [resultHistory, requestId]);
 
+	useEffect(() => {
+		// reset tags when the requestId changes,
+		// not when result history changes
+		setSelectedTag(null);
+		setAreTagsVisible(false);
+	}, [requestId]);
+
 	const handleFeedback = async (
 		feedbackId: number,
 		requestId: string,
@@ -126,6 +133,7 @@ export function AnswerFeedback({
 		setIsThumbsUpClicked(false);
 		setIsThumbsDownClicked(true);
 		setAreTagsVisible(true);
+		setSelectedTag(null);
 		await handleFeedback(6, requestId, getSessionId());
 	};
 

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -66,7 +66,6 @@ export interface Feedback {
 	id?: number;
 	created_at?: string;
 	feedback_id: number;
-	request_id: number;
 	session_id: string;
 }
 

--- a/src/lib/save-user-feedback.ts
+++ b/src/lib/save-user-feedback.ts
@@ -14,6 +14,7 @@ export async function saveUserFeedback({
 	signal,
 	sessionId,
 }: PostFeedbackProps): Promise<any> {
+	console.log("saveUserFeedback", userRequestId, feedbackId, sessionId);
 	const response = await fetch(`${API_URL}/feedbacks`, {
 		signal,
 		method: "POST",

--- a/src/lib/save-user-feedback.ts
+++ b/src/lib/save-user-feedback.ts
@@ -14,7 +14,6 @@ export async function saveUserFeedback({
 	signal,
 	sessionId,
 }: PostFeedbackProps): Promise<any> {
-	console.log("saveUserFeedback", userRequestId, feedbackId, sessionId);
 	const response = await fetch(`${API_URL}/feedbacks`, {
 		signal,
 		method: "POST",


### PR DESCRIPTION
there was a bug that providing feedback to a request would set the feedback to ALL requests in the `localStorage`. This PR fixes this bug. 