### PR TITLE
fix: transition bug in safari

### DIFF
--- a/src/components/ui/answer-feedback.tsx
+++ b/src/components/ui/answer-feedback.tsx
@@ -14,6 +14,7 @@ import { ThumbsDownSolidIcon } from "./icons/thumbs-down-solid";
 import { ThumbsUpIcon } from "./icons/thumbs-up";
 import { ThumbsUpSolidIcon } from "./icons/thumbs-up-solid";
 import { getSessionId } from "@/lib/get-session-id";
+import { ThankYouMessage } from "@/components/ui/thank-you-message";
 
 export function AnswerFeedback({
 	generatedAnswer,
@@ -152,10 +153,8 @@ export function AnswerFeedback({
 
 		await handleFeedback(id, requestId, getSessionId());
 
-		setTimeout(() => {
-			setAreTagsVisible(false);
-			showThenHideThankYouMessage();
-		}, 1000);
+		setTimeout(() => setAreTagsVisible(false), 1000);
+		setTimeout(() => showThenHideThankYouMessage(), 1100);
 	};
 
 	return (
@@ -237,18 +236,7 @@ export function AnswerFeedback({
 				</div>
 			</Transition>
 
-			<Transition
-				show={isThankYouMessageVisible}
-				enter="transition-opacity duration-700"
-				enterFrom="opacity-0"
-				enterTo="opacity-100"
-				leave="transition-opacity duration-500"
-				leaveFrom="opacity-100"
-				leaveTo="opacity-0"
-				className={`flex self-center rounded-lg shadow-md p-4 mx-4 bg-white w-fit`}
-			>
-				{texts.answerThankYou}
-			</Transition>
+			<ThankYouMessage isThankYouMessageVisible={isThankYouMessageVisible} />
 		</div>
 	);
 }

--- a/src/components/ui/thank-you-message.tsx
+++ b/src/components/ui/thank-you-message.tsx
@@ -1,0 +1,74 @@
+import { texts } from "@/lib/texts";
+import { useEffect, useState } from "react";
+
+const transitionDurationInMs = 500;
+const transitionSafetyBufferInMs = 100;
+const transitionDurationWithSafetyBufferInMs =
+	transitionDurationInMs + transitionSafetyBufferInMs;
+
+export function ThankYouMessage({
+	isThankYouMessageVisible,
+}: {
+	isThankYouMessageVisible: boolean;
+}) {
+	const [opacity, setOpacity] = useState(0);
+	const [isComponentInsideDOM, setIsComponentInsideDOM] = useState(false);
+
+	useEffect(() => {
+		/**
+		 * if the thank-you message appears (isThankYouMessageVisible === true),
+		 * first add the element to the DOM,
+		 * and only after a safety buffer of 100ms
+		 * make it visible via opacity-transition (from 0 to 1)
+		 */
+		if (isThankYouMessageVisible) {
+			setIsComponentInsideDOM(true);
+
+			const timeoutId = setTimeout(
+				() => setOpacity(1),
+				transitionSafetyBufferInMs,
+			);
+
+			return () => clearTimeout(timeoutId);
+		}
+
+		/**
+		 * if the thank-you message disappears (isThankYouMessageVisible === false),
+		 * first make it invisible via opacity-transition (from 1 to 0)
+		 * and only after the transition is done (500ms + 100ms safety buffer)
+		 * remove the element to the DOM
+		 */
+		setOpacity(0);
+
+		const timeoutId = setTimeout(
+			() => setIsComponentInsideDOM(false),
+			transitionDurationWithSafetyBufferInMs,
+		);
+
+		return () => clearTimeout(timeoutId);
+	}, [isThankYouMessageVisible]);
+
+	return (
+		<>
+			{isComponentInsideDOM && (
+				<div className={`flex w-full justify-center`}>
+					<div
+						className={`shadow-md rounded-lg p-4 mx-4 bg-white w-fit`}
+						style={{
+							/**
+							 * We need to use individual inline styles here because of a safari bug:
+							 * https://stackoverflow.com/questions/21767037/css-transitions-not-working-in-safari
+							 */
+							opacity,
+							transitionProperty: "opacity",
+							transitionDuration: `${transitionDurationInMs}ms`,
+							transitionTimingFunction: "cubic-bezier(0.4, 0, 0.2, 1)",
+						}}
+					>
+						{texts.answerThankYou}
+					</div>
+				</div>
+			)}
+		</>
+	);
+}


### PR DESCRIPTION
this fixes a visual bug in safari (see comments here: https://app.asana.com/0/1205231177119914/1206888585206828)

Apparently safari cannot interpret `transition-opacity` correctly (read more here: https://stackoverflow.com/questions/21767037/css-transitions-not-working-in-safari). Using individual inline styles fixed it.