### PR TITLE
chore: adapt num probes

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,5 +4,5 @@ NEXT_PUBLIC_MATOMO_SITE_ID=
 
 # num_probes should be set to sqrt(num_rows_of_table / 1000)
 # for reference, see https://github.com/pgvector/pgvector
-NEXT_PUBLIC_NUM_PROBES_SUMMARY=3
+NEXT_PUBLIC_NUM_PROBES_SUMMARY=4
 NEXT_PUBLIC_NUM_PROBES_CHUNKS=12

--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,8 @@
 NEXT_PUBLIC_KI_PARLA_API_URL=http://localhost:8080
 NEXT_PUBLIC_MATOMO_URL=
 NEXT_PUBLIC_MATOMO_SITE_ID=
+
+# num_probes should be set to sqrt(num_rows_of_table / 1000)
+# for reference, see https://github.com/pgvector/pgvector
+NEXT_PUBLIC_NUM_PROBES_SUMMARY=3
+NEXT_PUBLIC_NUM_PROBES_CHUNKS=12

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -83,19 +83,24 @@ export enum Algorithms {
 	SummariesThenChunks = "summaries-then-chunks",
 }
 
+// num_probes should be set to sqrt(num_rows_of_table / 1000)
+// for reference, see https://github.com/pgvector/pgvector
+const NUM_PROBES_SUMMARY = process.env.NEXT_PUBLIC_NUM_PROBES_SUMMARY || 4;
+const NUM_PROBES_CHUNKS = process.env.NEXT_PUBLIC_NUM_PROBES_CHUNKS || 12;
+
 export const availableAlgorithms = [
 	{
 		match_threshold: 0.85,
-		num_probes_summaries: 3,
-		num_probes_chunks: 9,
+		num_probes_summaries: NUM_PROBES_SUMMARY,
+		num_probes_chunks: NUM_PROBES_CHUNKS,
 		chunk_limit: 64,
 		document_limit: 20,
 		search_algorithm: Algorithms.ChunksOnly,
 	} as DocumentSearchBody,
 	{
 		match_threshold: 0.85,
-		num_probes_summaries: 3,
-		num_probes_chunks: 9,
+		num_probes_summaries: NUM_PROBES_SUMMARY,
+		num_probes_chunks: NUM_PROBES_CHUNKS,
 		chunk_limit: 128,
 		summary_limit: 16,
 		document_limit: 20,
@@ -103,8 +108,8 @@ export const availableAlgorithms = [
 	} as DocumentSearchBody,
 	{
 		match_threshold: 0.85,
-		num_probes_summaries: 3,
-		num_probes_chunks: 9,
+		num_probes_summaries: NUM_PROBES_SUMMARY,
+		num_probes_chunks: NUM_PROBES_CHUNKS,
 		summary_limit: 64,
 		document_limit: 20,
 		search_algorithm: Algorithms.SummariesThenChunks,


### PR DESCRIPTION
num_probes should be set to `sqrt(num_rows_of_table / 1000)`. for reference, see https://github.com/pgvector/pgvector

The num_probes value should be adapted regularly. For now, it's in the code, but in the future (after my vacation) we will find a way to automate this.

I have benchmarked this and the change does not cause any performance degradations. (direct db search with 512 sample questions, avg search time: ~0.3 seconds)

I have set the env variables in Vercel already.